### PR TITLE
Keep track of instrumented packages

### DIFF
--- a/app/src/main/java/saarland/cispa/artist/artistgui/MainActivityPresenter.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/MainActivityPresenter.java
@@ -29,11 +29,14 @@ import android.support.v4.app.Fragment;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-import saarland.cispa.artist.artistgui.utils.LogA;
 import saarland.cispa.artist.artistgui.compilation.CompilationContract;
 import saarland.cispa.artist.artistgui.compilation.CompilationPresenter;
 import saarland.cispa.artist.artistgui.compilation.CompileFragment;
+import saarland.cispa.artist.artistgui.settings.db.AddInstrumentedPackageToDbAsyncTask;
 import saarland.cispa.artist.artistgui.settings.manager.SettingsManager;
+import saarland.cispa.artist.artistgui.utils.LogA;
+
+import static android.app.Activity.RESULT_OK;
 
 class MainActivityPresenter implements MainActivityContract.Presenter {
 
@@ -91,7 +94,8 @@ class MainActivityPresenter implements MainActivityContract.Presenter {
 
     @Override
     public void processCompilationResult(int resultCode, Intent data) {
-        mCompilationPresenter.onCompilationFinished(resultCode, data);
+        mCompilationPresenter.onCompilationFinished(resultCode, data, resultCode == RESULT_OK ?
+                new AddInstrumentedPackageToDbAsyncTask(mActivity) : null);
     }
 
     @Override

--- a/app/src/main/java/saarland/cispa/artist/artistgui/Package.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/Package.java
@@ -17,32 +17,42 @@
  *
  */
 
-package saarland.cispa.artist.artistgui.packagelist.view;
+package saarland.cispa.artist.artistgui;
 
 import android.support.annotation.DrawableRes;
 
-class Package {
+public class Package {
 
     private String appName;
     private String packageName;
     private int appIconId;
+    private long lastInstrumentationTimestamp;
 
-    Package(String appName, String packageName, @DrawableRes int appIconId) {
+    public Package(String packageName, long lastInstrumentationTimestamp) {
+        this.packageName = packageName;
+        this.lastInstrumentationTimestamp = lastInstrumentationTimestamp;
+    }
+
+    public Package(String appName, String packageName, @DrawableRes int appIconId) {
         this.appName = appName;
         this.packageName = packageName;
         this.appIconId = appIconId;
     }
 
-    String getAppName() {
+    public String getAppName() {
         return appName;
     }
 
-    String getPackageName() {
+    public String getPackageName() {
         return packageName;
     }
 
-    int getAppIconId() {
+    public int getAppIconId() {
         return appIconId;
+    }
+
+    public long getLastInstrumentationTimestamp() {
+        return lastInstrumentationTimestamp;
     }
 
     @Override

--- a/app/src/main/java/saarland/cispa/artist/artistgui/compilation/CompilationContract.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/compilation/CompilationContract.java
@@ -24,6 +24,7 @@ import android.content.ServiceConnection;
 
 import saarland.cispa.artist.artistgui.base.BasePresenter;
 import saarland.cispa.artist.artistgui.base.BaseView;
+import saarland.cispa.artist.artistgui.settings.db.AddInstrumentedPackageToDbAsyncTask;
 
 public interface CompilationContract {
 
@@ -48,6 +49,8 @@ public interface CompilationContract {
 
         void executeIntentTasks(Intent intent);
 
-        void onCompilationFinished(int resultCode, Intent data);
+        void onCompilationFinished(int resultCode, Intent data,
+                                   AddInstrumentedPackageToDbAsyncTask
+                                           addInstrumentedPackageToDbAsyncTask);
     }
 }

--- a/app/src/main/java/saarland/cispa/artist/artistgui/compilation/CompilationPresenter.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/compilation/CompilationPresenter.java
@@ -25,6 +25,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;
+import android.os.AsyncTask;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
 
@@ -37,6 +38,7 @@ import saarland.cispa.artist.artistgui.MainActivity;
 import saarland.cispa.artist.artistgui.compilation.notification.CompileNotificationManager;
 import saarland.cispa.artist.artistgui.settings.config.ArtistAppConfig;
 import saarland.cispa.artist.android.AndroidUtils;
+import saarland.cispa.artist.artistgui.settings.db.AddInstrumentedPackageToDbAsyncTask;
 import trikita.log.Log;
 
 import static android.app.Activity.RESULT_OK;
@@ -206,6 +208,7 @@ public class CompilationPresenter implements CompilationContract.Presenter {
         mView.showCompilationResult(success, applicationName);
 
         if (success) {
+            new AddInstrumentedPackageToDbAsyncTask(mActivity).execute(applicationName);
             maybeStartRecompiledApp(applicationName);
         }
     }

--- a/app/src/main/java/saarland/cispa/artist/artistgui/compilation/CompilationPresenter.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/compilation/CompilationPresenter.java
@@ -155,7 +155,9 @@ public class CompilationPresenter implements CompilationContract.Presenter {
     }
 
     @Override
-    public void onCompilationFinished(int resultCode, Intent data) {
+    public void onCompilationFinished(int resultCode, Intent data,
+                                      AddInstrumentedPackageToDbAsyncTask
+                                              addInstrumentedPackageToDbAsyncTask) {
         String applicationName = "";
         if (data != null) {
             applicationName += data.getStringExtra(ArtistImpl.INTENT_EXTRA_APP_NAME);
@@ -165,7 +167,9 @@ public class CompilationPresenter implements CompilationContract.Presenter {
         mView.showCompilationResult(success, applicationName);
 
         if (success) {
-            new AddInstrumentedPackageToDbAsyncTask(mActivity).execute(applicationName);
+            if (addInstrumentedPackageToDbAsyncTask != null) {
+                addInstrumentedPackageToDbAsyncTask.execute(applicationName);
+            }
             maybeStartRecompiledApp(applicationName);
         }
     }

--- a/app/src/main/java/saarland/cispa/artist/artistgui/packagelist/view/AppIconCache.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/packagelist/view/AppIconCache.java
@@ -26,6 +26,8 @@ import android.graphics.drawable.Drawable;
 import android.util.DisplayMetrics;
 import android.util.LruCache;
 
+import saarland.cispa.artist.artistgui.Package;
+
 class AppIconCache extends LruCache<Package,Drawable> {
 
     private static final int MAX_SIZE = 15;

--- a/app/src/main/java/saarland/cispa/artist/artistgui/packagelist/view/PackageListAdapter.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/packagelist/view/PackageListAdapter.java
@@ -32,6 +32,7 @@ import android.widget.TextView;
 
 import java.util.List;
 
+import saarland.cispa.artist.artistgui.Package;
 import saarland.cispa.artist.artistgui.R;
 import saarland.cispa.artist.artistgui.packagelist.view.broadcastreceiver.OnPackageModifiedListener;
 

--- a/app/src/main/java/saarland/cispa/artist/artistgui/packagelist/view/PackageListView.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/packagelist/view/PackageListView.java
@@ -32,6 +32,7 @@ import android.util.AttributeSet;
 import java.util.ArrayList;
 import java.util.List;
 
+import saarland.cispa.artist.artistgui.Package;
 import saarland.cispa.artist.artistgui.packagelist.view.broadcastreceiver.PackageModifiedReceiver;
 
 public class PackageListView extends RecyclerView implements ReadInstalledPackagesAsyncTask

--- a/app/src/main/java/saarland/cispa/artist/artistgui/packagelist/view/ReadInstalledPackagesAsyncTask.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/packagelist/view/ReadInstalledPackagesAsyncTask.java
@@ -27,6 +27,8 @@ import android.os.AsyncTask;
 import java.util.ArrayList;
 import java.util.List;
 
+import saarland.cispa.artist.artistgui.Package;
+
 class ReadInstalledPackagesAsyncTask extends
         AsyncTask<PackageManager, Void, List<Package>> {
 

--- a/app/src/main/java/saarland/cispa/artist/artistgui/settings/db/AddInstrumentedPackageToDbAsyncTask.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/settings/db/AddInstrumentedPackageToDbAsyncTask.java
@@ -1,0 +1,43 @@
+/*
+ * The ARTist Project (https://artist.cispa.saarland)
+ *
+ * Copyright (C) 2017 CISPA (https://cispa.saarland), Saarland University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package saarland.cispa.artist.artistgui.settings.db;
+
+import android.content.Context;
+import android.os.AsyncTask;
+import android.support.annotation.NonNull;
+
+public class AddInstrumentedPackageToDbAsyncTask extends AsyncTask<String, Void, Void> {
+
+    private Context mContext;
+
+    public AddInstrumentedPackageToDbAsyncTask(Context context) {
+        this.mContext = context;
+    }
+
+    @Override
+    protected Void doInBackground(@NonNull String... params) {
+        InstrumentedPackagesManager manager = new DatabaseManager(mContext);
+        for (String p : params) {
+            manager.addInstrumentedPackage(p);
+        }
+        manager.onDestroy();
+        return null;
+    }
+}

--- a/app/src/main/java/saarland/cispa/artist/artistgui/settings/db/DatabaseManager.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/settings/db/DatabaseManager.java
@@ -1,0 +1,135 @@
+/*
+ * The ARTist Project (https://artist.cispa.saarland)
+ *
+ * Copyright (C) 2017 CISPA (https://cispa.saarland), Saarland University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package saarland.cispa.artist.artistgui.settings.db;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import saarland.cispa.artist.artistgui.Package;
+
+public class DatabaseManager implements InstrumentedPackagesManager {
+
+    private static String[] sInstrumentedAppsProjection = {
+            DbContract.PackageEntry.COLUMN_NAME_PACKAGE_NAME,
+            DbContract.PackageEntry.COLUMN_NAME_TIMESTAMP
+    };
+
+    private SQLiteDbHelper mDatabaseHelper;
+    private SQLiteDatabase mDatabase;
+
+    public DatabaseManager(Context context) {
+        mDatabaseHelper = new SQLiteDbHelper(context);
+    }
+
+    private void getWritableDatabase() {
+        if (mDatabase == null || mDatabase.isReadOnly()) {
+            mDatabase = mDatabaseHelper.getWritableDatabase();
+        }
+    }
+
+    public void addInstrumentedPackage(String packageName) {
+        getWritableDatabase();
+
+        ContentValues values = new ContentValues();
+        values.put(DbContract.PackageEntry.COLUMN_NAME_PACKAGE_NAME, packageName);
+        values.put(DbContract.PackageEntry.COLUMN_NAME_TIMESTAMP, System.currentTimeMillis());
+
+        if (!isEntryInPresent(packageName)) {
+            mDatabase.insert(DbContract.PackageEntry.TABLE_NAME, null, values);
+        } else {
+            String selection = DbContract.PackageEntry.COLUMN_NAME_PACKAGE_NAME + " LIKE ?";
+            String[] selectionArgs = {packageName};
+
+            mDatabase.update(
+                    DbContract.PackageEntry.TABLE_NAME,
+                    values,
+                    selection,
+                    selectionArgs);
+        }
+    }
+
+    private boolean isEntryInPresent(String packageName) {
+        String selection = DbContract.PackageEntry.COLUMN_NAME_PACKAGE_NAME + " = ?";
+        String[] selectionArgs = {packageName};
+
+        Cursor cursor = mDatabase.query(
+                DbContract.PackageEntry.TABLE_NAME,                     // The table to query
+                sInstrumentedAppsProjection,                               // The columns to return
+                selection,                                // The columns for the WHERE clause
+                selectionArgs,                            // The values for the WHERE clause
+                null,                                     // don't group the rows
+                null,                                     // don't filter by row groups
+                null                                 // The sort order
+        );
+        boolean isPresent = cursor.getCount() == 1;
+        cursor.close();
+        return isPresent;
+    }
+
+    public void removeUninstrumentedPackage(String packageName) {
+        getWritableDatabase();
+        String selection = DbContract.PackageEntry.COLUMN_NAME_PACKAGE_NAME + " LIKE ?";
+        String[] selectionArgs = {packageName};
+        mDatabase.delete(DbContract.PackageEntry.TABLE_NAME, selection, selectionArgs);
+    }
+
+    public List<Package> getAllInstrumentedApps() {
+        if (mDatabase == null) {
+            mDatabase = mDatabaseHelper.getReadableDatabase();
+        }
+
+        Cursor cursor = mDatabase.query(
+                DbContract.PackageEntry.TABLE_NAME,                     // The table to query
+                sInstrumentedAppsProjection,                               // The columns to return
+                null,                                // The columns for the WHERE clause
+                null,                            // The values for the WHERE clause
+                null,                                     // don't group the rows
+                null,                                     // don't filter by row groups
+                null                                 // The sort order
+        );
+
+        List<Package> packageList = extractCursorInformation(cursor);
+        cursor.close();
+        return packageList;
+    }
+
+    private List<Package> extractCursorInformation(Cursor cursor) {
+        List<Package> packageList = new ArrayList<>();
+        String packageName;
+        long lastInstrumentationTimestamp;
+        while (cursor.moveToNext()) {
+            packageName = cursor.getString(
+                    cursor.getColumnIndexOrThrow(DbContract.PackageEntry.COLUMN_NAME_PACKAGE_NAME));
+            lastInstrumentationTimestamp = cursor.getLong(
+                    cursor.getColumnIndexOrThrow(DbContract.PackageEntry.COLUMN_NAME_TIMESTAMP));
+            packageList.add(new Package(packageName, lastInstrumentationTimestamp));
+        }
+        return packageList;
+    }
+
+    public void onDestroy() {
+        mDatabaseHelper.close();
+    }
+}

--- a/app/src/main/java/saarland/cispa/artist/artistgui/settings/db/DbContract.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/settings/db/DbContract.java
@@ -27,6 +27,7 @@ public final class DbContract {
     static class PackageEntry {
         static final String TABLE_NAME = "instrumented_apps";
         static final String COLUMN_NAME_PACKAGE_NAME = "package_name";
-        static final String COLUMN_NAME_TIMESTAMP = "timestamp";
+        static final String COLUMN_NAME_TIMESTAMP = "last_instrumented_timestamp";
+        static final String COLUMN_NAME_KEEP_INSTRUMENTED = "keep_instrumented";
     }
 }

--- a/app/src/main/java/saarland/cispa/artist/artistgui/settings/db/DbContract.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/settings/db/DbContract.java
@@ -1,0 +1,32 @@
+/*
+ * The ARTist Project (https://artist.cispa.saarland)
+ *
+ * Copyright (C) 2017 CISPA (https://cispa.saarland), Saarland University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package saarland.cispa.artist.artistgui.settings.db;
+
+public final class DbContract {
+    private DbContract() {
+    }
+
+    /* Inner class that defines the table contents */
+    static class PackageEntry {
+        static final String TABLE_NAME = "instrumented_apps";
+        static final String COLUMN_NAME_PACKAGE_NAME = "package_name";
+        static final String COLUMN_NAME_TIMESTAMP = "timestamp";
+    }
+}

--- a/app/src/main/java/saarland/cispa/artist/artistgui/settings/db/InstrumentedPackagesManager.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/settings/db/InstrumentedPackagesManager.java
@@ -1,0 +1,34 @@
+/*
+ * The ARTist Project (https://artist.cispa.saarland)
+ *
+ * Copyright (C) 2017 CISPA (https://cispa.saarland), Saarland University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package saarland.cispa.artist.artistgui.settings.db;
+
+import java.util.List;
+
+import saarland.cispa.artist.artistgui.Package;
+
+public interface InstrumentedPackagesManager {
+    void addInstrumentedPackage(String packageName);
+
+    void removeUninstrumentedPackage(String packageName);
+
+    List<Package> getAllInstrumentedApps();
+
+    void onDestroy();
+}

--- a/app/src/main/java/saarland/cispa/artist/artistgui/settings/db/SQLiteDbHelper.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/settings/db/SQLiteDbHelper.java
@@ -1,0 +1,49 @@
+/*
+ * The ARTist Project (https://artist.cispa.saarland)
+ *
+ * Copyright (C) 2017 CISPA (https://cispa.saarland), Saarland University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package saarland.cispa.artist.artistgui.settings.db;
+
+import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+
+class SQLiteDbHelper extends SQLiteOpenHelper {
+
+
+
+    private static final String DATABASE_NAME = "AppInstrumentation.db";
+    private static final int DATABASE_VERSION = 1;
+
+    SQLiteDbHelper(Context context) {
+        super(context, DATABASE_NAME, null, DATABASE_VERSION);
+    }
+
+    @Override
+    public void onCreate(SQLiteDatabase db) {
+        db.execSQL("CREATE TABLE " + DbContract.PackageEntry.TABLE_NAME + " ("
+                + DbContract.PackageEntry.COLUMN_NAME_PACKAGE_NAME + " TEXT PRIMARY KEY,"
+                + DbContract.PackageEntry.COLUMN_NAME_TIMESTAMP + " INTEGER"
+                + ") WITHOUT ROWID;");
+    }
+
+    @Override
+    public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+
+    }
+}

--- a/app/src/main/java/saarland/cispa/artist/artistgui/settings/db/SQLiteDbHelper.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/settings/db/SQLiteDbHelper.java
@@ -38,7 +38,8 @@ class SQLiteDbHelper extends SQLiteOpenHelper {
     public void onCreate(SQLiteDatabase db) {
         db.execSQL("CREATE TABLE " + DbContract.PackageEntry.TABLE_NAME + " ("
                 + DbContract.PackageEntry.COLUMN_NAME_PACKAGE_NAME + " TEXT PRIMARY KEY,"
-                + DbContract.PackageEntry.COLUMN_NAME_TIMESTAMP + " INTEGER"
+                + DbContract.PackageEntry.COLUMN_NAME_TIMESTAMP + " INTEGER,"
+                + DbContract.PackageEntry.COLUMN_NAME_KEEP_INSTRUMENTED + " INTEGER"
                 + ") WITHOUT ROWID;");
     }
 

--- a/app/src/test/java/saarland/cispa/artist/artistgui/CompilationPresenterTest.java
+++ b/app/src/test/java/saarland/cispa/artist/artistgui/CompilationPresenterTest.java
@@ -110,7 +110,7 @@ public class CompilationPresenterTest {
         // Don't launch app. We can't test it currently.
         when(mSettingsManager.shouldLaunchActivityAfterCompilation()).thenReturn(false);
 
-        mPresenter.onCompilationFinished(Activity.RESULT_OK, mIntent);
+        mPresenter.onCompilationFinished(Activity.RESULT_OK, mIntent, null);
 
         verify(mView).showCompilationResult(mBoolArgCaptor.capture(), mStringArgCaptor.capture());
         assertTrue(mBoolArgCaptor.getValue());
@@ -124,7 +124,7 @@ public class CompilationPresenterTest {
         // Don't launch app. We can't test it currently.
         when(mSettingsManager.shouldLaunchActivityAfterCompilation()).thenReturn(false);
 
-        mPresenter.onCompilationFinished(Activity.RESULT_CANCELED, mIntent);
+        mPresenter.onCompilationFinished(Activity.RESULT_CANCELED, mIntent, null);
 
         verify(mView).showCompilationResult(mBoolArgCaptor.capture(), mStringArgCaptor.capture());
         assertFalse(mBoolArgCaptor.getValue());


### PR DESCRIPTION
In order to be able to undo app instrumentation (#10) or reinstrument apps after update (#2) we need to keep track of the instrumented packages. A SQLite database is used to store the information