### PR TITLE
Fallback to android icon if package has no icon

### DIFF
--- a/app/src/main/java/saarland/cispa/artist/artistgui/packagelist/view/AppIconCache.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/packagelist/view/AppIconCache.java
@@ -21,29 +21,29 @@ package saarland.cispa.artist.artistgui.packagelist.view;
 
 import android.content.Context;
 import android.content.pm.PackageManager;
-import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.util.DisplayMetrics;
 import android.util.LruCache;
 
-class AppIconCache extends LruCache<Package,Drawable> {
+class AppIconCache extends LruCache<Package, Drawable> {
 
     private static final int MAX_SIZE = 15;
+    private static final Package sDefaultIconPackage =
+            new Package("Default_Icon", "default_app_icon", 0);
 
     private Context mContext;
-    private Package mDefaultAppIconKey;
-
 
     AppIconCache(Context context) {
         super(MAX_SIZE);
         mContext = context;
-        mDefaultAppIconKey = new Package("Default Icon", "default_app_icon", 0);
     }
 
     @Override
     protected Drawable create(Package packageEntry) {
-        if (packageEntry.equals(mDefaultAppIconKey)) {
+        if (packageEntry.equals(sDefaultIconPackage)) {
             return mContext.getDrawable(android.R.mipmap.sym_def_app_icon);
+        } else if (packageEntry.getAppIconId() == android.R.mipmap.sym_def_app_icon) {
+            return get(sDefaultIconPackage);
         }
 
         Drawable appIcon = null;
@@ -56,8 +56,6 @@ class AppIconCache extends LruCache<Package,Drawable> {
 
         } catch (PackageManager.NameNotFoundException e) {
             e.printStackTrace();
-        } catch (Resources.NotFoundException e) {
-            return get(mDefaultAppIconKey);
         }
 
         return appIcon;

--- a/app/src/main/java/saarland/cispa/artist/artistgui/packagelist/view/ReadInstalledPackagesAsyncTask.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/packagelist/view/ReadInstalledPackagesAsyncTask.java
@@ -36,7 +36,7 @@ class ReadInstalledPackagesAsyncTask extends
 
     private OnReadInstalledPackages mResultCallback;
 
-    public ReadInstalledPackagesAsyncTask(OnReadInstalledPackages callback) {
+    ReadInstalledPackagesAsyncTask(OnReadInstalledPackages callback) {
         super();
         mResultCallback = callback;
     }
@@ -48,12 +48,17 @@ class ReadInstalledPackagesAsyncTask extends
                 .getInstalledPackages(PackageManager.GET_ACTIVITIES);
 
         List<Package> packageList = new ArrayList<>();
+        ApplicationInfo applicationInfo;
+        String appName;
+        int appIconId;
         for (PackageInfo packageInfo : packageInfoList) {
             if (!isCancelled()) {
-                ApplicationInfo applicationInfo = packageInfo.applicationInfo;
-                String appName = packageManager.getApplicationLabel(applicationInfo).toString();
-                packageList.add(new Package(appName, packageInfo.packageName,
-                        applicationInfo.icon));
+                applicationInfo = packageInfo.applicationInfo;
+                appName = packageManager.getApplicationLabel(applicationInfo).toString();
+                appIconId = applicationInfo.icon == 0 ?
+                        android.R.mipmap.sym_def_app_icon : applicationInfo.icon;
+
+                packageList.add(new Package(appName, packageInfo.packageName, appIconId));
             }
         }
 


### PR DESCRIPTION
The applicationInfo.icon value is 0 if the package has no icon. So we
can set the icon to the default android icon there
(ReadInstalledPackagesAsyncTask) instead of catching the
Resources.NotFoundException exception and falling back to the default
android icon like before. Also the default android icon dummy package
can be static.