### PR TITLE
Undo app instrumentation

### DIFF
--- a/app/src/main/java/saarland/cispa/artist/artistgui/MainActivityPresenter.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/MainActivityPresenter.java
@@ -126,7 +126,6 @@ class MainActivityPresenter implements MainActivityContract.Presenter {
             case INSTRUMENTATION_FRAGMENT:
                 mAppListFragment = (AppListFragment) selectedFragment;
                 mAppListPresenter = new AppListPresenter(mAppListFragment, mSettingsManager);
-                mAppListFragment.setPresenter(mAppListPresenter);
                 break;
         }
         mSelectedFragmentId = selectedFragmentId;

--- a/app/src/main/java/saarland/cispa/artist/artistgui/Package.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/Package.java
@@ -53,6 +53,14 @@ public class Package implements Parcelable {
         this.appIconId = appIconId;
     }
 
+    /**
+     * Can be called after a instrumentation removal to reset the package state.
+     */
+    public void reset() {
+        lastInstrumentationTimestamp = 0;
+        keepInstrumented = false;
+    }
+
     public String getAppName() {
         return appName;
     }

--- a/app/src/main/java/saarland/cispa/artist/artistgui/appdetails/AppDetailsDialogContract.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/appdetails/AppDetailsDialogContract.java
@@ -20,6 +20,7 @@
 package saarland.cispa.artist.artistgui.appdetails;
 
 import android.graphics.drawable.Drawable;
+import android.os.Bundle;
 
 import saarland.cispa.artist.artistgui.Package;
 import saarland.cispa.artist.artistgui.base.BasePresenter;
@@ -31,9 +32,11 @@ interface AppDetailsDialogContract {
 
         void setLastInstrumentationText(String lastInstrumented);
 
-        void activateKeepInstrumentedViews(Package app);
+        void updateKeepInstrumentedViews(boolean enable, Package app);
 
-        void updateInstrumentationButton(boolean instrumented, String packageName);
+        void updateInstrumentationButton(boolean instrumented);
+
+        void updateRemoveInstrumentationButton(boolean isInstrumented);
 
         void showInstrumentationProgress();
     }
@@ -45,7 +48,11 @@ interface AppDetailsDialogContract {
 
         void startInstrumentation();
 
+        void removeInstrumentation();
+
         void handleInstrumentationResult(boolean isSuccess);
+
+        void saveInstanceState(Bundle outState);
 
         void setSelectedPackage(Package selectedPackage);
     }

--- a/app/src/main/java/saarland/cispa/artist/artistgui/applist/loader/AppListChangedReceiver.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/applist/loader/AppListChangedReceiver.java
@@ -23,6 +23,9 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.support.v4.content.LocalBroadcastManager;
+
+import saarland.cispa.artist.artistgui.instrumentation.progress.ProgressPublisher;
 
 public class AppListChangedReceiver extends BroadcastReceiver {
 
@@ -38,6 +41,11 @@ public class AppListChangedReceiver extends BroadcastReceiver {
         filter.addAction(Intent.ACTION_PACKAGE_REMOVED);
         filter.addDataScheme("package");
         context.registerReceiver(this, filter);
+
+        final IntentFilter localFilter = new IntentFilter(ProgressPublisher
+                .ACTION_INSTRUMENTATION_REMOVED);
+        LocalBroadcastManager broadcastManager = LocalBroadcastManager.getInstance(context);
+        broadcastManager.registerReceiver(this, localFilter);
     }
 
     @Override

--- a/app/src/main/java/saarland/cispa/artist/artistgui/instrumentation/RemoveInstrumentationAsyncTask.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/instrumentation/RemoveInstrumentationAsyncTask.java
@@ -1,0 +1,36 @@
+/*
+ * The ARTist Project (https://artist.cispa.saarland)
+ *
+ * Copyright (C) 2017 CISPA (https://cispa.saarland), Saarland University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package saarland.cispa.artist.artistgui.instrumentation;
+
+import android.os.AsyncTask;
+import android.support.annotation.NonNull;
+
+import saarland.cispa.artist.artistgui.utils.ProcessExecutor;
+
+public class RemoveInstrumentationAsyncTask extends AsyncTask<String, Void, Void> {
+    @Override
+    protected Void doInBackground(@NonNull String... oatFilePaths) {
+        for (String filePath : oatFilePaths) {
+            String command = String.format("rm %s", filePath);
+            ProcessExecutor.execute(command, true);
+        }
+        return null;
+    }
+}

--- a/app/src/main/java/saarland/cispa/artist/artistgui/instrumentation/progress/ProgressPublisher.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/instrumentation/progress/ProgressPublisher.java
@@ -48,6 +48,12 @@ public class ProgressPublisher implements ProgressListener {
     public static final String EXTRA_INSTRUMENTATION_RESULT =
             "saarland.cispa.artist.artistgui.extra.INSTRUMENTATION_RESULT";
 
+    /**
+     * Instrumentation removed action
+     */
+    public static final String ACTION_INSTRUMENTATION_REMOVED =
+            "saarland.cispa.artist.artistgui.action.INSTRUMENTATION_REMOVED";
+
     private LocalBroadcastManager mBroadcastManager;
 
     public ProgressPublisher(LocalBroadcastManager broadcastManager) {

--- a/app/src/main/java/saarland/cispa/artist/artistgui/settings/db/operations/RemovePackagesFromDbAyncTask.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/settings/db/operations/RemovePackagesFromDbAyncTask.java
@@ -1,0 +1,45 @@
+/*
+ * The ARTist Project (https://artist.cispa.saarland)
+ *
+ * Copyright (C) 2017 CISPA (https://cispa.saarland), Saarland University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package saarland.cispa.artist.artistgui.settings.db.operations;
+
+import android.content.Context;
+import android.os.AsyncTask;
+
+import saarland.cispa.artist.artistgui.settings.db.DatabaseManager;
+import saarland.cispa.artist.artistgui.settings.db.InstrumentedPackagesManager;
+
+public class RemovePackagesFromDbAyncTask extends AsyncTask<String, Void, Void> {
+
+    private Context mContext;
+
+    public RemovePackagesFromDbAyncTask(Context context) {
+        this.mContext = context;
+    }
+
+    @Override
+    protected Void doInBackground(String... params) {
+        InstrumentedPackagesManager manager = new DatabaseManager(mContext);
+        for (String packageName : params) {
+            manager.removeUninstrumentedPackage(packageName);
+        }
+        manager.onDestroy();
+        return null;
+    }
+}

--- a/app/src/main/res/layout/fragment_app_details.xml
+++ b/app/src/main/res/layout/fragment_app_details.xml
@@ -79,6 +79,23 @@
         app:layout_constraintStart_toStartOf="parent" />
 
     <Button
+        android:id="@+id/remove_instrumentation_button"
+        style="?android:attr/borderlessButtonStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginTop="24dp"
+        android:text="@string/remove_instrumentation"
+        android:textColor="@android:color/holo_red_light"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/instrument_button"
+        app:layout_constraintTop_toBottomOf="@id/keep_instrumented_switch_info_text"
+        tools:text="Remove instrumentation"
+        tools:visibility="visible" />
+
+    <Button
         android:id="@+id/instrument_button"
         style="?android:attr/borderlessButtonStyle"
         android:layout_width="wrap_content"
@@ -89,6 +106,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/keep_instrumented_switch_info_text"
-        tools:text="Recompile" />
+        tools:text="Reinstrument" />
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
     <string name="keep_instrumented_switch_info">Reinstrument after updates</string>
     <string name="instrument_app">Instrument</string>
     <string name="reinstrument_app">Reinstrument</string>
+    <string name="remove_instrumentation">Remove Instrumentation</string>
     <string name="never_instrumented">Never instrumented</string>
     <string name="last_instrumentation">Last instrumentation: %s</string>
 


### PR DESCRIPTION
Deletes the new oat file. The app will either be compiled again by the system dex2oat
or simply interpreted. In any case, the instrumentation should be gone.

Related issues: #10 #8 