### PR TITLE
Backup merged APK, keep latest copy, closes #7

### DIFF
--- a/app/src/main/java/saarland/cispa/artist/artistgui/instrumentation/config/ArtistRunConfig.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/instrumentation/config/ArtistRunConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The ARTist Project (https://artist.cispa.saarland)
  * <p>
  * Copyright (C) 2017 CISPA (https://cispa.saarland), Saarland University
@@ -18,6 +18,7 @@
  * @author "Oliver Schranz <oliver.schranz@cispa.saarland>"
  * @author "Sebastian Weisgerber <weisgerber@cispa.saarland>"
  */
+
 package saarland.cispa.artist.artistgui.instrumentation.config;
 
 import java.io.File;
@@ -58,8 +59,6 @@ public class ArtistRunConfig {
     public String api_level = "";
 
     public int COMPILER_THREADS = -1;
-
-    public boolean BACKUP_APK_MERGED = false;
 
     public String asset_path_artist_root = "";
     public String asset_path_dex2oat = "";
@@ -103,7 +102,6 @@ public class ArtistRunConfig {
                 ", app_package_name=                 '" + app_package_name + '\'' + "\n" +
                 ", app_oat_architecture=             '" + app_oat_architecture + '\'' + "\n" +
                 ", COMPILER_THREADS=                 '" + COMPILER_THREADS + "'\n" +
-                ", BACKUP_APK_MERGED=                '" + BACKUP_APK_MERGED + "'\n" +
                 ", asset_path_artist_root=           '" + asset_path_artist_root + '\'' + "\n" +
                 ", asset_path_dex2oat=               '" + asset_path_dex2oat + '\'' + "\n" +
                 ", asset_path_dex2oat_libs=          '" + asset_path_dex2oat_libs + '\'' + "\n" +
@@ -128,10 +126,6 @@ public class ArtistRunConfig {
     }
 
     public boolean isAssetCodeLib() {
-        if (codeLibName != null) {
-            return codeLibName.startsWith(ArtistUtils.CODELIB_ASSET);
-        } else {
-            return false;
-        }
+        return codeLibName != null && codeLibName.startsWith(ArtistUtils.CODELIB_ASSET);
     }
 }

--- a/app/src/main/java/saarland/cispa/artist/artistgui/instrumentation/stages/InstrumentationStagesImpl.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/instrumentation/stages/InstrumentationStagesImpl.java
@@ -229,31 +229,25 @@ public class InstrumentationStagesImpl implements InstrumentationStages {
 
     @Override
     public void backupMergedApk() {
-        if (!mRunConfig.BACKUP_APK_MERGED) {
-            Log.v(TAG, "Skip: backupMergedApk()");
-            return;
-        }
         Log.v(TAG, "backupMergedApk()");
+        final File externalStorage = mContext.getExternalFilesDir(null);
+        if (externalStorage != null) {
+            final String mergedApkBackupPath = externalStorage.getAbsolutePath() + File.separator
+                    + "last_merged_signed_instrumented_app.apk";
 
-        final File sdcard = Environment.getExternalStorageDirectory();
-        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss", Locale.getDefault());
-        Date date = new Date();
+            reportProgressDetails("Backing up Merged APK: " + mergedApkBackupPath);
 
-        final String mergedApkBackupPath = sdcard.getAbsolutePath() + File.separator
-                + mRunConfig.app_package_name + "_merged_signed_" + dateFormat.format(date) + ".apk";
+            final String cmd_backup_merged_apk = "cp " + mRunConfig.app_apk_merged_signed_file_path +
+                    " " + mergedApkBackupPath;
 
-        reportProgressDetails("Backing up Merged APK: " + mergedApkBackupPath);
+            boolean success = ProcessExecutor.execute(cmd_backup_merged_apk, true,
+                    ProcessExecutor.processName(mRunConfig.app_package_name, "cp_backup_merged"));
 
-        final String cmd_backup_merged_apk = "cp " + mRunConfig.app_apk_merged_signed_file_path +
-                " " + mergedApkBackupPath;
-
-        boolean success = ProcessExecutor.execute(cmd_backup_merged_apk, true,
-                ProcessExecutor.processName(mRunConfig.app_package_name, "cp_backup_merged"));
-
-        if (success) {
-            Log.d(TAG, "backupMergedApk() Success: " + mergedApkBackupPath);
-        } else {
-            Log.e(TAG, "backupMergedApk() Failed:  " + mergedApkBackupPath);
+            if (success) {
+                Log.d(TAG, "backupMergedApk() Success: " + mergedApkBackupPath);
+            } else {
+                Log.e(TAG, "backupMergedApk() Failed:  " + mergedApkBackupPath);
+            }
         }
     }
 

--- a/app/src/main/java/saarland/cispa/artist/artistgui/settings/config/ArtistConfigFactory.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/settings/config/ArtistConfigFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The ARTist Project (https://artist.cispa.saarland)
  * <p>
  * Copyright (C) 2017 CISPA (https://cispa.saarland), Saarland University
@@ -47,8 +47,8 @@ public class ArtistConfigFactory {
     private static final String TAG = "ArtistConfigFactory";
     private static final String CODE_LIB_ASSET = "assetcodelib.apk";
 
-    public final static String PATH_ASSET_ARTIST_ROOT = "artist";
-    public final static String PATH_ASSET_ARTIST_BIN_PREFIX = PATH_ASSET_ARTIST_ROOT + File.separator + "android-";
+    private final static String PATH_ASSET_ARTIST_ROOT = "artist";
+    private final static String PATH_ASSET_ARTIST_BIN_PREFIX = PATH_ASSET_ARTIST_ROOT + File.separator + "android-";
 
     public static ArtistRunConfig buildArtistRunConfig(final Context context, final String appPackageName) {
         ArtistRunConfig artistConfig = new ArtistRunConfig();
@@ -70,7 +70,6 @@ public class ArtistConfigFactory {
 
         final String compiler_threads = sharedPref.getString(ArtistAppConfig.KEY_PREF_COMPILER_THREADS, "-1");
         artistConfig.COMPILER_THREADS = Integer.parseInt(compiler_threads);
-        artistConfig.BACKUP_APK_MERGED = sharedPref.getBoolean(ArtistAppConfig.KEY_PREF_BACKUP_APK_MERGED, false);
 
         final PackageInfo packageInfo = getPackageInfo(context, appPackageName);
 
@@ -126,7 +125,6 @@ public class ArtistConfigFactory {
                 String codeLibName = userCodeLib.replaceFirst(ArtistUtils.CODELIB_IMPORTED, "");
                 codeLibPath = AndroidUtils.getFilesDirLocation(context, ArtistAppConfig.APP_FOLDER_CODELIBS + File.separator + codeLibName);
             } else if (userCodeLib.startsWith(ArtistUtils.CODELIB_ASSET)) {
-                String codeLibName = userCodeLib.replaceFirst(ArtistUtils.CODELIB_ASSET, "");
                 codeLibPath = AndroidUtils.getFilesDirLocation(context, CODE_LIB_ASSET);
             }
 


### PR DESCRIPTION
In the new version of the UI, we dropped the setting to activate merged apk backup.
Now the app keeps a copy of the last merged apk and overwrites the previous one.
This way, we make sure to not fill up too much space but still be able to debug efficiently.

The backup location is managed by the system, so when the user deletes the app the apk gets
removed as well (/sdcard/Android/data/saarland.cispa.artist.artistgui/files/).