### PR TITLE
All app updates trigger (re)compilation, closes #47

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
             android:launchMode="singleInstance"
             android:parentActivityName=".MainActivity" />
 
-        <receiver android:name=".PackageUpdatedReceiver">
+        <receiver android:name=".broadcastreceiver.PackageUpdatedReceiver">
             <intent-filter>
                 <action android:name="android.intent.action.PACKAGE_REPLACED" />
                 <data android:scheme="package" />

--- a/app/src/main/java/saarland/cispa/artist/artistgui/appdetails/AppDetailsDialogPresenter.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/appdetails/AppDetailsDialogPresenter.java
@@ -161,7 +161,7 @@ public class AppDetailsDialogPresenter implements AppDetailsDialogContract.Prese
             mView.updateKeepInstrumentedViews(true, mSelectedPackage);
             mView.updateRemoveInstrumentationButton(true);
 
-            if (wasInstrumented) {
+            if (!wasInstrumented) {
                 new AddInstrumentedPackageToDbAsyncTask(mDatabase).execute(mSelectedPackage);
             } else {
                 new PersistPackageToDbAsyncTask(mDatabase).execute(mSelectedPackage);

--- a/app/src/main/java/saarland/cispa/artist/artistgui/broadcastreceiver/InstrumentUpdatedPackagesAsyncTask.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/broadcastreceiver/InstrumentUpdatedPackagesAsyncTask.java
@@ -1,0 +1,59 @@
+/*
+ * The ARTist Project (https://artist.cispa.saarland)
+ *
+ * Copyright (C) 2017 CISPA (https://cispa.saarland), Saarland University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package saarland.cispa.artist.artistgui.broadcastreceiver;
+
+import android.content.Intent;
+import android.os.AsyncTask;
+import android.support.annotation.NonNull;
+
+import saarland.cispa.artist.artistgui.Application;
+import saarland.cispa.artist.artistgui.database.Package;
+import saarland.cispa.artist.artistgui.database.PackageDao;
+import saarland.cispa.artist.artistgui.instrumentation.InstrumentationService;
+
+class InstrumentUpdatedPackagesAsyncTask extends AsyncTask<String, Void, Void> {
+
+    private Application appContext;
+
+    InstrumentUpdatedPackagesAsyncTask(Application appContext) {
+        this.appContext = appContext;
+    }
+
+    @Override
+    protected Void doInBackground(String... packages) {
+        String packageName = packages[0];
+        Package app = getPackage(packageName);
+        if (app != null && app.keepInstrumented) {
+            startService(packageName);
+        }
+        return null;
+    }
+
+    private Package getPackage(@NonNull String packageName) {
+        PackageDao dao = appContext.getDatabase().packageDao();
+        return dao.get(packageName);
+    }
+
+    private void startService(@NonNull String packageName) {
+        Intent serviceIntent = new Intent(appContext, InstrumentationService.class);
+        serviceIntent.putExtra(InstrumentationService.INTENT_KEY_APP_NAME, packageName);
+        appContext.startService(serviceIntent);
+    }
+}

--- a/app/src/main/java/saarland/cispa/artist/artistgui/broadcastreceiver/PackageUpdatedReceiver.java
+++ b/app/src/main/java/saarland/cispa/artist/artistgui/broadcastreceiver/PackageUpdatedReceiver.java
@@ -17,13 +17,14 @@
  *
  */
 
-package saarland.cispa.artist.artistgui;
+package saarland.cispa.artist.artistgui.broadcastreceiver;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.AsyncTask;
 
-import saarland.cispa.artist.artistgui.instrumentation.InstrumentationService;
+import saarland.cispa.artist.artistgui.Application;
 
 public class PackageUpdatedReceiver extends BroadcastReceiver {
 
@@ -31,13 +32,20 @@ public class PackageUpdatedReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
+        String packageName = extractPackageName(intent);
+        if (packageName != null) {
+            final Application appContext = (Application) context.getApplicationContext();
+            new InstrumentUpdatedPackagesAsyncTask(appContext)
+                    .executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, packageName);
+        }
+    }
+
+    private String extractPackageName(Intent intent) {
         String packageName = intent.getDataString();
         if (packageName != null) {
-            packageName = packageName.replace(PACKAGE_NAME_PREFIX, "");
-
-            Intent serviceIntent = new Intent(context, InstrumentationService.class);
-            serviceIntent.putExtra(InstrumentationService.INTENT_KEY_APP_NAME, packageName);
-            context.startService(serviceIntent);
+            return packageName.replace(PACKAGE_NAME_PREFIX, "");
+        } else {
+            return null;
         }
     }
 }


### PR DESCRIPTION
PackageUpdatedReceiver filters the incoming package names and
starts instrumentation tasks whenever the updated app was instrumented
before and the keep instrumented option is enabled.