### PR TITLE
Travis: Setup Emulator to run UI tests (fixes #81)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,14 @@
 language: android
 android:
   components:
-    # Uncomment the lines below if you want to
-    # use the latest revision of Android SDK Tools
     - tools
     # The BuildTools version used by your project
-    - build-tools-26.0.1
+    - build-tools-25.0.3
     - platform-tools
     - tools # Duplicate `tools` entry is by reason
 
     # The SDK version used to compile your project
-    - android-26
-
-    # Additional components
-    # - extra-google-google_play_services
-    # - extra-google-m2repository
-    # - extra-android-m2repository
-    # - addon-google_apis-google-19
-
-    # Specify at least one system image,
-    # if you need to run emulator(s) during your tests
-    # - sys-img-armeabi-v7a-android-22
-    # - sys-img-armeabi-v7a-android-17
+    - android-25
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -33,11 +20,17 @@ cache:
     - $HOME/.gradle/wrapper/
     - $HOME/.android/build-cache
 
+# Install Emulator and android images
 install:
-  # List and delete unnecessary components to free space
-  - sdkmanager --list || true
-  - echo yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2"
-  - echo yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.2"
+  - echo y | sdkmanager "emulator"
+  - echo y | sdkmanager "system-images;android-25;google_apis;armeabi-v7a"
+
+# Emulator Management: Create, Start and Wait (use latest emulator)
+before_script:
+  - echo no | avdmanager create avd -f -n android-25 -k "system-images;android-25;google_apis;armeabi-v7a"
+  - PATH="${ANDROID_HOME}emulator:${PATH}" && emulator -no-accel -no-audio -no-window -gpu swiftshader_indirect @android-25 &
+  - android-wait-for-emulator
+  - adb shell input keyevent 82 &
 
 script:
 - ./gradlew build connectedCheck


### PR DESCRIPTION
In Travis we run ./gradlew build connectedCheck (line 43). "build" builds the app and runs the unit tests. "connectedCheck" executes the instrumentation tests on an Android device (physical) or an emulator. However we don't create/start an emulator.

This pull request installs the latest android emulator and the android-25 image. Afterwards it starts the emulator before executing the instrumentation tests.